### PR TITLE
add specific to oracle date quotting

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -126,6 +126,10 @@ module ActiveRecord
           "0".freeze
         end
 
+        def quoted_date(value)
+          super(value.change(usec: 0))
+        end
+
         def _type_cast(value)
           case value
           when Type::OracleEnhanced::TimestampTz::Data, Type::OracleEnhanced::TimestampLtz::Data


### PR DESCRIPTION
override default implementation to remove `usec` part, it prevents incorrect data format for Oracle DATE columns